### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,12 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -1,9 +1,15 @@
 ---
 name: integration test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
@@ -13,6 +19,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: |
           go install -ldflags "-X main.version=0.0.1-0 -X main.commit=$GITHUB_SHA -X main.date=$(date +"%Y-%m-%dT%H:%M:%SZ%:z" | tr -d '+')" ./cmd/ghaperf
       - run: ghaperf -v

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,28 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/workflow_call_integration_test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the GitHub Actions workflows.

## Changes

- `.github/workflows/release.yaml`
  - Bump go-release-workflow ref: `# v8.0.0` -> `884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0`
  - Add `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `release` job
- `.github/workflows/test.yaml`
  - On the `test` job (local call of `workflow_call_test.yaml`): pass `TAKUMI_GUARD_BOT_ID` and add `id-token: write`
- `.github/workflows/workflow_call_test.yaml`
  - Declare `TAKUMI_GUARD_BOT_ID` as a required `workflow_call` secret
  - Bump go-test-full-workflow ref: `# v5.0.2` -> `98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0`
  - Pass `TAKUMI_GUARD_BOT_ID` and add `id-token: write` to both the `integration-test` (local call) and `test` jobs
- `.github/workflows/workflow_call_integration_test.yaml`
  - Declare `TAKUMI_GUARD_BOT_ID` as a required `workflow_call` secret
  - Add `contents: read` and `id-token: write` to the `integration-test` job
  - Add setup step `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` after `actions/setup-go` and before `go install`
- `.github/workflows/autofix.yaml`
  - Bump go-autofix-action ref: `# v0.1.12` -> `9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13`
  - Add `takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}` input
  - Add `id-token: write` to the `autofix` job

## Note

go-test-full-workflow was bumped across a MAJOR version (v5.0.2 -> v6.0.0).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository for these workflows to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)