### PR TITLE
fix: use promoted fields in struct literals

### DIFF
--- a/pkg/github/list_jobs.go
+++ b/pkg/github/list_jobs.go
@@ -8,9 +8,7 @@ import (
 func (c *Client) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64, attempt int) ([]*WorkflowJob, error) {
 	list := c.getListJobsFunc(attempt)
 	opts := &ListWorkflowJobsOptions{
-		ListOptions: ListOptions{
-			PerPage: maxPerPage,
-		},
+		PerPage: maxPerPage,
 	}
 	arr := []*WorkflowJob{}
 	for range 10 { // max 1000 jobs
@@ -38,10 +36,8 @@ func (c *Client) getListJobsFunc(attempt int) func(ctx context.Context, owner, r
 	}
 	return func(ctx context.Context, owner, repo string, runID int64, page int) (*Jobs, *Response, error) {
 		return c.actions.ListWorkflowJobs(ctx, owner, repo, runID, &ListWorkflowJobsOptions{
-			ListOptions: ListOptions{
-				Page:    page,
-				PerPage: maxPerPage,
-			},
+			Page:    page,
+			PerPage: maxPerPage,
 		})
 	}
 }

--- a/pkg/github/list_workflow_runs.go
+++ b/pkg/github/list_workflow_runs.go
@@ -15,9 +15,7 @@ func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo string, fileN
 		HeadSHA:             opts.HeadSHA,
 		ExcludePullRequests: opts.ExcludePullRequests,
 		CheckSuiteID:        opts.CheckSuiteID,
-		ListOptions: ListOptions{
-			PerPage: maxPerPage,
-		},
+		PerPage:             maxPerPage,
 	}
 	if maxCount < maxPerPage {
 		o.PerPage = maxCount


### PR DESCRIPTION
Fixes the CI failure on the Renovate PR this branches from, so that the Go 1.27 module directive can be merged.

Raising the `go` directive to 1.27.0 turns on `modernize`'s `embedlit` check, which reports struct literals that name an embedded field explicitly:

```
embedlit: embedded field type can be removed from struct literal (modernize)
```

Go 1.27 lets a composite literal set a promoted field directly, so the wrapper is no longer needed:

```diff
 opts := &ListWorkflowJobsOptions{
-    ListOptions: ListOptions{
-        PerPage: maxPerPage,
-    },
+    PerPage: maxPerPage,
 }
```

Applied with `golangci-lint run --fix`, not by hand. No behaviour change — the same fields are set on the same embedded struct.

Verified locally with golangci-lint v2.13.0 under Go 1.27: `go build ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all pass.

Base is the Renovate branch, so merging this puts the fix on it.
