### PR TITLE
fix: use tint.NewTextHandler

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -10,7 +10,7 @@ import (
 
 func New(w io.Writer, version string) (*slog.Logger, *slog.LevelVar) {
 	level := &slog.LevelVar{}
-	return slog.New(tint.NewHandler(w, &tint.Options{
+	return slog.New(tint.NewTextHandler(w, &tint.Options{
 		Level: level,
 	})).With("program", "ghaperf", "ghaperf_version", version), level
 }


### PR DESCRIPTION
Fixes the CI failure on the Renovate PR this branches from, so that tint v1.2.0 can be merged.

v1.2.0 deprecates `tint.NewHandler` in favour of `NewTextHandler` and marks it `//go:fix inline`, so govet's `inline` analyzer flags every call site:

```
inline: Call of tint.NewHandler should be inlined (govet)
```

`NewHandler` is now just a delegate, so this is a rename and nothing else:

```go
// tint v1.2.0 handler.go
// Deprecated: Use [NewTextHandler] instead.
//
//go:fix inline
func NewHandler(w io.Writer, opts *Options) slog.Handler {
	return NewTextHandler(w, opts)
}
```

Verified locally: `go build ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all pass.

Base is the Renovate branch, so merging this puts the fix on it.
